### PR TITLE
disable py312 wheels due to numpy incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
 # Disable building PyPy wheels on all platforms
-skip = 'pp* cp36-* *-win32 *i686'
+skip = 'pp* cp36-* cp312-* *-win32 *i686'
 
 # On an Linux Intel runner with qemu installed, build Intel and ARM wheels
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
related: https://github.com/numpy/numpy/issues/23808