### PR TITLE
Modernize version management: static pyproject.toml + importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'speedups'
-dynamic = ['version']
+version = '1.4.0'
 description = 'Library with C and Cython code for speeding up common operations.'
 readme = 'README.rst'
 license = 'BSD-3-Clause'
@@ -57,9 +57,6 @@ requires = [
     'wheel>=0.37.1',
 ]
 build-backend = 'setuptools.build_meta'
-
-[tool.setuptools.dynamic]
-version = {attr = 'speedups.__about__.__version__'}
 
 [tool.setuptools.packages.find]
 include = ['speedups']

--- a/speedups/__about__.py
+++ b/speedups/__about__.py
@@ -1,6 +1,12 @@
+from importlib.metadata import version as _version
+
+try:
+    __version__: str = _version('speedups')
+except Exception:
+    __version__ = '0.0.0'
+
 __package_name__ = 'speedups'
 __import_name__ = 'speedups'
-__version__ = '1.4.0'
 __author__ = 'Rick van Hattem, Joren Hammudoglu'
 __author_email__ = 'Wolph@Wol.ph, jhammudoglu@gmail.com'
 __description__ = (

--- a/speedups/__about__.py
+++ b/speedups/__about__.py
@@ -1,12 +1,14 @@
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
-
-try:
-    __version__: str = _version('speedups')
-except Exception:
-    __version__ = '0.0.0'
 
 __package_name__ = 'speedups'
 __import_name__ = 'speedups'
+
+try:
+    __version__: str = _version(__package_name__)
+except PackageNotFoundError:
+    __version__ = '0.0.0'
+
 __author__ = 'Rick van Hattem, Joren Hammudoglu'
 __author_email__ = 'Wolph@Wol.ph, jhammudoglu@gmail.com'
 __description__ = (


### PR DESCRIPTION
## Summary
- Remove `dynamic = ['version']` and `[tool.setuptools.dynamic]` from pyproject.toml; add static `version = '1.4.0'`
- Replace hardcoded `__version__` in `__about__.py` with `importlib.metadata.version()` lookup, matching the numpy-stl pattern
- Single source of truth for version is now the `version` field in pyproject.toml

## Test plan
- [x] `uv sync --all-groups` builds and installs `speedups==1.4.0`
- [x] `uv run python -c "from speedups.__about__ import __version__; print(__version__)"` prints `1.4.0`
- [x] `uv run ruff check .` passes with no issues
- [ ] `uv run pytest tests/test_arrays.py -v` -- requires PostgreSQL (not available in this environment); failures are pre-existing and unrelated to this change