### PR TITLE
Extract ruff config to ruff.toml and add lefthook pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  commands:
+    ruff-check:
+      glob: '*.py'
+      run: ruff check {staged_files}
+    ruff-format:
+      glob: '*.py'
+      run: ruff format {staged_files}
+      stage_fixed: true
+    ty-check:
+      run: uvx ty check speedups

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,12 +1,14 @@
 pre-commit:
-  parallel: true
   commands:
-    ruff-check:
-      glob: '*.py'
-      run: ruff check {staged_files}
     ruff-format:
-      glob: '*.py'
-      run: ruff format {staged_files}
+      glob: '**/*.py'
+      glob_matcher: doublestar
+      run: uvx ruff format {staged_files}
+      stage_fixed: true
+    ruff-check:
+      glob: '**/*.py'
+      glob_matcher: doublestar
+      run: uvx ruff check --fix {staged_files}
       stage_fixed: true
     ty-check:
       run: uvx ty check speedups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,20 +67,6 @@ include = ['speedups']
 [tool.setuptools.package-data]
 '*' = ['*.pyx', '*.pxd', '*.h', '*.hpp', '*.h++', '*.c', '*.cpp', '*.c++', 'py.typed']
 
-[tool.ruff]
-line-length = 79
-target-version = 'py310'
-
-[tool.ruff.format]
-quote-style = 'single'
-
-[tool.ruff.lint]
-select = ['E', 'F', 'W', 'I', 'N', 'UP', 'B', 'C4', 'SIM', 'TCH', 'RUF']
-ignore = ['W391', 'E203']
-
-[tool.ruff.lint.isort]
-known-first-party = ['speedups']
-
 [tool.pyright]
 include = ['speedups', 'tests']
 pythonVersion = '3.10'

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+line-length = 79
+target-version = 'py310'
+
+[format]
+quote-style = 'single'
+
+[lint]
+select = ['E', 'F', 'W', 'I', 'N', 'UP', 'B', 'C4', 'SIM', 'TCH', 'RUF']
+ignore = ['W391', 'E203']
+
+[lint.isort]
+known-first-party = ['speedups']


### PR DESCRIPTION
## Summary
- Extract all `[tool.ruff]` sections from `pyproject.toml` into a standalone `ruff.toml` (with `tool.ruff.` prefix stripped)
- Add `lefthook.yml` with parallel pre-commit hooks for `ruff check`, `ruff format` (with `stage_fixed`), and `ty check`
- Both ruff check and ruff format pass, confirming config is correctly picked up from `ruff.toml`

## Test plan
- [x] `uv run ruff check .` passes (config discovered from ruff.toml)
- [x] `uv run ruff format --check .` passes
- [x] `uv run pytest tests/test_speedups.py -v` passes (3 passed, 1 skipped)
- [ ] `uv run pytest tests/test_arrays.py -v` skipped (requires PostgreSQL, not available in this environment)