### PR TITLE
Modernize build workflow for PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: build-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_quick:
     name: Fast wheel build
@@ -67,8 +71,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: astral-sh/setup-uv@v7
+
       - name: Build SDist
-        run: pipx run build --sdist
+        run: uv build --sdist
 
       - uses: actions/upload-artifact@v4
         with:
@@ -78,6 +84,7 @@ jobs:
   upload_all:
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
 
@@ -90,4 +97,4 @@ jobs:
 
       - run: ls -Ralh dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.11
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `environment: pypi` to the upload job for OIDC Trusted Publishing best practice
- Update `pypa/gh-action-pypi-publish` from pinned `v1.8.11` to `release/v1` for automatic minor/patch updates
- Replace `pipx run build --sdist` with `uv build --sdist` to align sdist build with the uv migration
- Add concurrency group to cancel duplicate workflow runs on the same branch

## Test plan
- [x] YAML validated with `yaml.safe_load()`
- [x] Unit tests pass (3 passed, 1 skipped)
- [ ] Verify workflow runs correctly on next tag push